### PR TITLE
feat: 議論評価軸7軸拡充 + レーダーチャート + 審判バイアス補正 (#8)

### DIFF
--- a/apps/backend/src/schemas/sessions.ts
+++ b/apps/backend/src/schemas/sessions.ts
@@ -25,6 +25,18 @@ export const JudgeVerdictSchema = z
 			description: "Novelty score of perspectives presented (1-10)",
 			example: 6,
 		}),
+		inclusiveness_score: z.number().int().min(1).max(10).optional().openapi({
+			description: "Inclusiveness score - how well diverse perspectives are included (1-10)",
+			example: 7,
+		}),
+		transformation_score: z.number().int().min(1).max(10).optional().openapi({
+			description: "Opinion transformation score - how much opinions evolved (1-10)",
+			example: 6,
+		}),
+		cross_reference_score: z.number().int().min(1).max(10).optional().openapi({
+			description: "Cross-reference score - how well participants referenced each other (1-10)",
+			example: 7,
+		}),
 		summary: z.string().openapi({
 			description: "Summary of the deliberation evaluation",
 			example:

--- a/apps/backend/src/types/database.ts
+++ b/apps/backend/src/types/database.ts
@@ -90,6 +90,9 @@ export interface JudgeVerdict {
 	cooperation_score: number;
 	convergence_score: number;
 	novelty_score: number;
+	inclusiveness_score?: number;
+	transformation_score?: number;
+	cross_reference_score?: number;
 	summary: string;
 	highlights: string[];
 	consensus: string;

--- a/apps/frontend/app/components/design-system/RadarChart.tsx
+++ b/apps/frontend/app/components/design-system/RadarChart.tsx
@@ -1,0 +1,160 @@
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+
+export interface RadarAxis {
+	key: string;
+	label: string;
+	description: string;
+}
+
+interface RadarChartProps {
+	axes: RadarAxis[];
+	data: Record<string, number | undefined>;
+	maxValue?: number;
+}
+
+const SIZE = 300;
+const CENTER = SIZE / 2;
+const RADIUS = 100;
+const LABEL_RADIUS = 128;
+const GRID_LEVELS = 5;
+
+function polarToCartesian(angle: number, radius: number): { x: number; y: number } {
+	const rad = angle - Math.PI / 2;
+	return {
+		x: CENTER + radius * Math.cos(rad),
+		y: CENTER + radius * Math.sin(rad),
+	};
+}
+
+function buildPolygonPoints(count: number, radius: number): string {
+	const step = (2 * Math.PI) / count;
+	return Array.from({ length: count }, (_, i) => {
+		const { x, y } = polarToCartesian(i * step, radius);
+		return `${x},${y}`;
+	}).join(" ");
+}
+
+/** Determine CSS transform so the label extends away from the chart center. */
+function getLabelTransform(x: number, y: number): string {
+	const dx = x - CENTER;
+	const dy = y - CENTER;
+
+	let tx = "-50%";
+	if (dx > 15) tx = "0%";
+	else if (dx < -15) tx = "-100%";
+
+	let ty = "-50%";
+	if (dy > 30) ty = "0%";
+	else if (dy < -30) ty = "-100%";
+
+	return `translate(${tx}, ${ty})`;
+}
+
+/**
+ * Pure SVG radar chart with dynamic axis count.
+ * Labels are placed at each vertex with Popover for descriptions.
+ */
+export function RadarChart({ axes, data, maxValue = 10 }: RadarChartProps) {
+	const activeAxes = axes.filter((a) => data[a.key] != null);
+	const count = activeAxes.length;
+
+	if (count < 3) return null;
+
+	const step = (2 * Math.PI) / count;
+
+	const dataPoints = activeAxes.map((axis, i) => {
+		const value = Math.min(data[axis.key] ?? 0, maxValue);
+		const r = (value / maxValue) * RADIUS;
+		return polarToCartesian(i * step, r);
+	});
+	const dataPolygon = dataPoints.map((p) => `${p.x},${p.y}`).join(" ");
+
+	return (
+		<div className="relative mx-auto w-full max-w-[280px] overflow-visible">
+			<svg
+				viewBox={`0 0 ${SIZE} ${SIZE}`}
+				className="w-full block"
+				role="img"
+				aria-label="レーダーチャート"
+			>
+				{/* Grid polygons */}
+				{[1, 2, 3, 4, 5].map((level) => {
+					const r = (level / GRID_LEVELS) * RADIUS;
+					return (
+						<polygon
+							key={`grid-${level}`}
+							points={buildPolygonPoints(count, r)}
+							fill="none"
+							className="stroke-border"
+							strokeWidth={level === GRID_LEVELS ? 1.5 : 0.5}
+						/>
+					);
+				})}
+
+				{/* Axis lines */}
+				{activeAxes.map((axis) => {
+					const idx = activeAxes.indexOf(axis);
+					const { x, y } = polarToCartesian(idx * step, RADIUS);
+					return (
+						<line
+							key={`axis-${axis.key}`}
+							x1={CENTER}
+							y1={CENTER}
+							x2={x}
+							y2={y}
+							className="stroke-border"
+							strokeWidth={0.5}
+						/>
+					);
+				})}
+
+				{/* Data polygon */}
+				<polygon points={dataPolygon} className="fill-primary/20 stroke-primary" strokeWidth={2} />
+
+				{/* Data points */}
+				{dataPoints.map((p, i) => (
+					<circle
+						key={`point-${activeAxes[i].key}`}
+						cx={p.x}
+						cy={p.y}
+						r={4}
+						className="fill-primary"
+					/>
+				))}
+			</svg>
+
+			{/* Vertex labels (HTML overlay for Popover support) */}
+			{activeAxes.map((axis, i) => {
+				const pos = polarToCartesian(i * step, LABEL_RADIUS);
+				const score = data[axis.key] ?? 0;
+				const leftPct = (pos.x / SIZE) * 100;
+				const topPct = (pos.y / SIZE) * 100;
+
+				return (
+					<Popover key={axis.key}>
+						<PopoverTrigger asChild>
+							<button
+								type="button"
+								className="absolute whitespace-nowrap text-xs leading-tight transition-colors hover:text-primary"
+								style={{
+									left: `${leftPct}%`,
+									top: `${topPct}%`,
+									transform: getLabelTransform(pos.x, pos.y),
+								}}
+							>
+								<span className="text-muted-foreground">{axis.label}</span>
+								<span className="ml-0.5 font-bold text-primary">{score}</span>
+							</button>
+						</PopoverTrigger>
+						<PopoverContent className="w-60">
+							<p className="font-semibold mb-1">
+								{axis.label}: {score} / {maxValue}
+							</p>
+							<p className="text-sm text-muted-foreground">{axis.description}</p>
+						</PopoverContent>
+					</Popover>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/frontend/app/components/design-system/index.ts
+++ b/apps/frontend/app/components/design-system/index.ts
@@ -9,6 +9,8 @@ export { LoadingState } from "./LoadingState";
 export { PageHeader } from "./PageHeader";
 export { Pagination } from "./Pagination";
 export { ProgressBar } from "./ProgressBar";
+export type { RadarAxis } from "./RadarChart";
+export { RadarChart } from "./RadarChart";
 export { ScoreCard } from "./ScoreCard";
 export { Spinner } from "./Spinner";
 export { StatusBadge } from "./StatusBadge";

--- a/apps/frontend/app/components/ui/dialog.tsx
+++ b/apps/frontend/app/components/ui/dialog.tsx
@@ -1,9 +1,8 @@
-import * as React from "react";
 import { XIcon } from "lucide-react";
 import { Dialog as DialogPrimitive } from "radix-ui";
-
-import { cn } from "~/lib/utils";
+import type * as React from "react";
 import { Button } from "~/components/ui/button";
+import { cn } from "~/lib/utils";
 
 function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
 	return <DialogPrimitive.Root data-slot="dialog" {...props} />;

--- a/apps/frontend/app/components/ui/popover.tsx
+++ b/apps/frontend/app/components/ui/popover.tsx
@@ -1,0 +1,72 @@
+import { Popover as PopoverPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "~/lib/utils";
+
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+	return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+	return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+	className,
+	align = "center",
+	sideOffset = 4,
+	...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+	return (
+		<PopoverPrimitive.Portal>
+			<PopoverPrimitive.Content
+				data-slot="popover-content"
+				align={align}
+				sideOffset={sideOffset}
+				className={cn(
+					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+					className,
+				)}
+				{...props}
+			/>
+		</PopoverPrimitive.Portal>
+	);
+}
+
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+	return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="popover-header"
+			className={cn("flex flex-col gap-1 text-sm", className)}
+			{...props}
+		/>
+	);
+}
+
+function PopoverTitle({ className, ...props }: React.ComponentProps<"h2">) {
+	return <div data-slot="popover-title" className={cn("font-medium", className)} {...props} />;
+}
+
+function PopoverDescription({ className, ...props }: React.ComponentProps<"p">) {
+	return (
+		<p
+			data-slot="popover-description"
+			className={cn("text-muted-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Popover,
+	PopoverTrigger,
+	PopoverContent,
+	PopoverAnchor,
+	PopoverHeader,
+	PopoverTitle,
+	PopoverDescription,
+};

--- a/apps/frontend/app/lib/types.ts
+++ b/apps/frontend/app/lib/types.ts
@@ -99,6 +99,9 @@ export interface JudgeVerdict {
 	cooperation_score: number;
 	convergence_score: number;
 	novelty_score: number;
+	inclusiveness_score?: number;
+	transformation_score?: number;
+	cross_reference_score?: number;
 	summary: string;
 	highlights: string[];
 	consensus?: string;

--- a/apps/frontend/app/routes/dashboard.tsx
+++ b/apps/frontend/app/routes/dashboard.tsx
@@ -12,19 +12,19 @@ import {
 import { Button } from "~/components/ui/button";
 import { Card, CardContent } from "~/components/ui/card";
 import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
-} from "~/components/ui/dialog";
-import {
 	Carousel,
 	CarouselContent,
 	CarouselItem,
 	CarouselNext,
 	CarouselPrevious,
 } from "~/components/ui/carousel";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "~/components/ui/dialog";
 import { ProtectedRoute } from "../components/ProtectedRoute";
 import {
 	type AgentSummary,

--- a/apps/frontend/app/routes/sessions/detail.tsx
+++ b/apps/frontend/app/routes/sessions/detail.tsx
@@ -2,13 +2,14 @@ import { SignedIn, SignedOut, useAuth } from "@clerk/clerk-react";
 import { ChevronRight } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router";
+import type { RadarAxis } from "../../components/design-system";
 import {
 	BackLink,
 	FormField,
 	InfoAlert,
 	LoadingState,
 	ProgressBar,
-	ScoreCard,
+	RadarChart,
 	StatusBadge,
 } from "../../components/design-system";
 import { SessionTimeline } from "../../components/SessionTimeline";
@@ -215,6 +216,40 @@ export default function SessionDetailPage() {
 	);
 }
 
+const JUDGE_AXES: RadarAxis[] = [
+	{ key: "quality_score", label: "議論の質", description: "論理性、根拠の明確さ、議論の深さ" },
+	{
+		key: "cooperation_score",
+		label: "協調性",
+		description: "建設的な対話、相互理解、攻撃性の有無",
+	},
+	{
+		key: "convergence_score",
+		label: "まとまり度",
+		description: "明確な合意形成、曖昧さの排除",
+	},
+	{
+		key: "novelty_score",
+		label: "新規性",
+		description: "創造性、既存の通説からの脱却",
+	},
+	{
+		key: "inclusiveness_score",
+		label: "包摂性",
+		description: "多様な立場・背景への配慮、少数意見の尊重",
+	},
+	{
+		key: "transformation_score",
+		label: "意見変容度",
+		description: "議論を通じた意見の変化・発展、柔軟性",
+	},
+	{
+		key: "cross_reference_score",
+		label: "相互参照度",
+		description: "他者の発言への言及・引用、対話の連続性",
+	},
+];
+
 /** Completed session section: judge verdict + collapsible summary */
 function CompletedSection({
 	summary,
@@ -226,6 +261,9 @@ function CompletedSection({
 		cooperation_score: number;
 		convergence_score: number;
 		novelty_score: number;
+		inclusiveness_score?: number;
+		transformation_score?: number;
+		cross_reference_score?: number;
 		summary: string;
 		highlights?: string[];
 		consensus?: string;
@@ -241,16 +279,10 @@ function CompletedSection({
 					<div className={summary ? "mb-4" : ""}>
 						<h2 className="text-lg font-bold mb-2">ジャッジ評価</h2>
 						<div className="space-y-4">
-							<div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-								<ScoreCard label="議論の質" value={judgeVerdict.quality_score} color="blue" />
-								<ScoreCard label="協調性" value={judgeVerdict.cooperation_score} color="green" />
-								<ScoreCard
-									label="まとまり度"
-									value={judgeVerdict.convergence_score}
-									color="purple"
-								/>
-								<ScoreCard label="新規性" value={judgeVerdict.novelty_score} color="orange" />
-							</div>
+							<RadarChart
+								axes={JUDGE_AXES}
+								data={judgeVerdict as unknown as Record<string, number | undefined>}
+							/>
 
 							<div>
 								<h3 className="font-semibold text-foreground mb-2">まとめ</h3>


### PR DESCRIPTION
- 評価軸を4→7に拡充（包摂性・意見変容度・相互参照度を追加）
- ScoreCardグリッドをSVGレーダーチャートに差し替え（頂点ラベル+Popover説明）
- 審判プロンプトにルーブリック・CoT・分布指示・否定強制を導入し甘採点を補正
- 旧4軸セッションとの後方互換を維持