### PR TITLE
fix: チュートリアル改善 - ユーザー単位チェック + トピック共有化 + トピック進化スキップ

### DIFF
--- a/apps/backend/migrations/0007_tutorial_sessions.sql
+++ b/apps/backend/migrations/0007_tutorial_sessions.sql
@@ -1,6 +1,17 @@
 -- Add is_tutorial flag to sessions table
 ALTER TABLE sessions ADD COLUMN is_tutorial INTEGER DEFAULT 0;
 
+-- Insert tutorial topic (shared across all tutorial sessions, never archived)
+INSERT OR IGNORE INTO topics (id, title, description, status, created_at, updated_at)
+VALUES (
+  't0000000-0000-4000-8000-000000000001',
+  'AIと人間の未来の関係',
+  'AIが日常生活に浸透する中で、人間とAIはどのような関係を築いていくべきでしょうか？協力、共存、それとも距離を置くべき？あなたの考えを自由に語ってください。',
+  'active',
+  strftime('%s', 'now'),
+  strftime('%s', 'now')
+);
+
 -- Insert system user for NPC agents
 INSERT OR IGNORE INTO users (id, created_at, updated_at)
 VALUES ('system', strftime('%s', 'now'), strftime('%s', 'now'));

--- a/apps/backend/src/config/constants.ts
+++ b/apps/backend/src/config/constants.ts
@@ -247,15 +247,10 @@ export const TUTORIAL_MAX_TURNS = 3;
  */
 export const TUTORIAL_TURN_DELAY_SECONDS = 90;
 
-
 /**
  * Tutorial topic
  */
-export const TUTORIAL_TOPIC = {
-	title: "AIと人間の未来の関係",
-	description:
-		"AIが日常生活に浸透する中で、人間とAIはどのような関係を築いていくべきでしょうか？協力、共存、それとも距離を置くべき？あなたの考えを自由に語ってください。",
-} as const;
+export const TUTORIAL_TOPIC_ID = "t0000000-0000-4000-8000-000000000001";
 
 // ============================================================================
 // Queue Configuration

--- a/apps/backend/src/queue/turn-completion.ts
+++ b/apps/backend/src/queue/turn-completion.ts
@@ -265,8 +265,10 @@ async function completeSession(
 		// 5. Update agent personas based on user inputs
 		await updateAgentPersonas(env, session.id);
 
-		// 6. Evolve topics: generate next topics and archive the current one
-		await evolveTopics(env, session, summary, judgeVerdict);
+		// 6. Evolve topics (skip for tutorials — topic is shared and permanent)
+		if (!session.is_tutorial) {
+			await evolveTopics(env, session, summary, judgeVerdict);
+		}
 	} catch (error) {
 		console.error(`[Session Completion] Failed to complete session ${session.id}:`, error);
 		// Mark as completed even if summary/verdict generation fails


### PR DESCRIPTION
- チュートリアル済み判定をエージェント単位からユーザー単位に変更
- チュートリアルトピックをmigrationで1つだけ作成し全セッションで共有
- チュートリアルセッション完了時のトピック進化・アーカイブをスキップ