### PR TITLE
feat: セッション詳細にsummary表示追加 + UI世界観テキスト修正

### DIFF
--- a/apps/backend/src/routes/sessions.ts
+++ b/apps/backend/src/routes/sessions.ts
@@ -357,7 +357,7 @@ publicSessions.openapi(getSessionTurnsRoute, async (c) => {
 
 		// Get turns for this session
 		const turns = await c.env.DB.prepare(
-			`SELECT id, turn_number, status, completed_at
+			`SELECT id, turn_number, status, summary, completed_at
        FROM turns
        WHERE session_id = ?
        ORDER BY turn_number ASC`,
@@ -369,7 +369,7 @@ publicSessions.openapi(getSessionTurnsRoute, async (c) => {
 		const turnsWithStatements = await Promise.all(
 			turns.results.map(async (turn) => {
 				const statements = await c.env.DB.prepare(
-					`SELECT s.id, s.agent_id, s.content, s.created_at, a.name as agent_name
+					`SELECT s.id, s.agent_id, s.content, s.summary, s.created_at, a.name as agent_name
            FROM statements s
            JOIN agents a ON s.agent_id = a.id
            WHERE s.turn_id = ?
@@ -382,11 +382,13 @@ publicSessions.openapi(getSessionTurnsRoute, async (c) => {
 					id: turn.id,
 					turn_number: turn.turn_number,
 					status: turn.status,
+					summary: turn.summary ?? null,
 					statements: statements.results.map((stmt) => ({
 						id: stmt.id,
 						agent_id: stmt.agent_id,
 						agent_name: stmt.agent_name,
 						content: stmt.content,
+						summary: stmt.summary ?? null,
 						created_at: stmt.created_at,
 					})),
 					completed_at: turn.completed_at,

--- a/apps/backend/src/schemas/sessions.ts
+++ b/apps/backend/src/schemas/sessions.ts
@@ -270,6 +270,10 @@ export const StatementSchema = z
 			description: "Statement content",
 			example: "I believe renewable energy is essential for...",
 		}),
+		summary: z.string().nullable().openapi({
+			description: "One-line summary of the statement",
+			example: "再生可能エネルギーの重要性を主張",
+		}),
 		created_at: z.number().int().openapi({
 			description: "Unix timestamp (seconds) when created",
 			example: 1704067200,
@@ -293,6 +297,9 @@ export const TurnSchema = z
 		status: TurnStatusEnum.openapi({
 			description: "Turn status (pending | processing | completed | failed)",
 			example: "completed",
+		}),
+		summary: z.string().nullable().openapi({
+			description: "Rolling summary of the discussion up to this turn",
 		}),
 		statements: z.array(StatementSchema).openapi({
 			description: "Statements made during this turn",

--- a/apps/frontend/app/hooks/backend/index.ts
+++ b/apps/frontend/app/hooks/backend/index.ts
@@ -545,6 +545,11 @@ export interface Statement {
   agent_name: string;
   /** Statement content */
   content: string;
+  /**
+   * One-line summary of the statement
+   * @nullable
+   */
+  summary: string | null;
   /** Unix timestamp (seconds) when created */
   created_at: number;
 }
@@ -556,6 +561,11 @@ export interface Turn {
   turn_number: number;
   /** Turn status (pending | processing | completed | failed) */
   status: TurnStatus;
+  /**
+   * Rolling summary of the discussion up to this turn
+   * @nullable
+   */
+  summary: string | null;
   /** Statements made during this turn */
   statements: Statement[];
   /**

--- a/apps/frontend/app/routes/sessions/detail.tsx
+++ b/apps/frontend/app/routes/sessions/detail.tsx
@@ -192,7 +192,12 @@ export default function SessionDetailPage() {
 						)}
 
 						{/* Timeline - main content */}
-						<SessionTimeline turns={turns} myAgentIds={myAgentIds} maxTurns={session.max_turns} />
+						<SessionTimeline
+							turns={turns}
+							myAgentIds={myAgentIds}
+							maxTurns={session.max_turns}
+							isCompleted={session.status === "completed"}
+						/>
 
 						{/* Timestamps */}
 						{(session.started_at || session.completed_at) && (
@@ -376,7 +381,7 @@ function TutorialBanner({ isCompleted }: { isCompleted: boolean }) {
 			<CardContent className="py-4">
 				<div className="flex items-center justify-between flex-wrap gap-3">
 					<div>
-						<p className="font-bold text-sm">これはチュートリアルマッチです</p>
+						<p className="font-bold text-sm">これはお試しの議論です</p>
 						<p className="text-xs text-muted-foreground mt-1">
 							{isCompleted
 								? "お疲れさまでした! これが議論の基本的な流れです。"
@@ -392,19 +397,19 @@ function TutorialBanner({ isCompleted }: { isCompleted: boolean }) {
 						<DialogContent className="max-h-[calc(100vh-2rem)] overflow-y-auto">
 							<DialogHeader>
 								<DialogTitle>熟議牧場のルール</DialogTitle>
-								<DialogDescription>実際のセッションはこのように進みます</DialogDescription>
+								<DialogDescription>実際の議論はこのように進みます</DialogDescription>
 							</DialogHeader>
 							<div className="space-y-4 text-sm">
 								<div>
 									<h3 className="font-semibold mb-1">議論の開始</h3>
 									<p className="text-muted-foreground">
-										6時間ごとに新しい議論が自動的に始まります。あなたのなかまは自動的に参加します。
+										4時間ごとに新しい議論が自動的に始まります。あなたのなかまは自動的に参加します。
 									</p>
 								</div>
 								<div>
 									<h3 className="font-semibold mb-1">議論の流れ</h3>
 									<p className="text-muted-foreground">
-										4体のなかまが参加し、最大10ターンの議論を行います。各ターンは15分ごとに進行します。
+										4体のなかまがランダムで参加し、最大10ターンの議論を行います。各ターンは15分ごとに進行します。
 									</p>
 								</div>
 								<div>
@@ -418,13 +423,13 @@ function TutorialBanner({ isCompleted }: { isCompleted: boolean }) {
 								<div>
 									<h3 className="font-semibold mb-1">成長のしくみ</h3>
 									<p className="text-muted-foreground">
-										あなたのフィードバックを受けて、なかまの性格や考え方が少しずつ変化していきます。
+										あなたのふりかえりを受けて、なかまの性格や考え方が少しずつ変化していきます。
 									</p>
 								</div>
 								<div>
 									<h3 className="font-semibold mb-1">評価</h3>
 									<p className="text-muted-foreground">
-										議論が終わると、AIジャッジが7つの観点で評価します。なかまの成長を見守りましょう。
+										議論が終わると、7つの観点で評価されます。なかまの成長を見守りましょう。
 									</p>
 								</div>
 							</div>


### PR DESCRIPTION
- turns/statementsにsummary フィールド追加（バックエンド・フロントエンド）
- SessionTimelineの完了時表示改善・折りたたみUI改善
- チュートリアルバナーのテキストを牧場世界観に統一